### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is primarily to serve the TTS extension in [SillyTavern](https://github.com
 `pip install silero-api-server`
 
 ## Starting Server
-`py -m silero_api_server` will run on default ip and port (0.0.0.0:8001)
+`python -m silero_api_server` will run on default ip and port (0.0.0.0:8001)
 
 ```
 usage: silero_api_server [-h] [-o HOST] [-p PORT]


### PR DESCRIPTION
$ py -m silero_api_server
usage: py [-x] [-l] [-c PRE_CMD] [-C POST_CMD] [-V] [-h] [expression]
py: error: unrecognized arguments: -m

here should be `python -m`, not `py`