### PR TITLE
Containerization of server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:22.04
+RUN apt update && apt install -y python3-pip git
+COPY . .
+RUN pip install . 
+CMD ["python3", "-m", "silero_api_server"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ On first run of server, two operations occur automatically. These may take a min
 1. The model will be downloaded 
 2. Voice samples will be generated. 
 
+## Deploying server as a container
+
+You can build an image from current source by running `docker build -t silero:latest .` in the top
+level of repository. Server can then be deployed as a container with `docker run -p 8001:8001 silero:latest`.
+
 # API Docs
 API Docs can be accessed from [http://localhost:8001/docs](http://localhost:8001/docs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
   "uvicorn",
   "soundfile",
   "numpy",
-  "pydub"
+  "pydub",
+  "requests",
 ]
 dynamic=["version"]
 


### PR DESCRIPTION
Running the server as a container will improve security and simplify deployment. Instead of having to create a virtual environment one can just build an image with `docker build -t silero:latest .` in repo and run the resulting image with `docker run -p 8001:8001 silero:latest`. Thus keeping things nicely isolated and reproducible. It would be better if the image was already in a repo, for example on hub.docker.com. But that would involve setting up automation.

Requests were missing from pyproject.toml, this made installation from source needlessly complicated.
